### PR TITLE
if deps/ dir doesn't exist make it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ if not USE_CYTHON:
         assert os.path.exists(os.path.join("pypolyagamma", "parallel.cpp"))
 
 # download GSL if we don't have it in deps
-assert os.path.exists('deps')
+if not os.path.exists('deps'):
+    os.makedirs('deps')
 gslurl = 'http://open-source-box.org/gsl/gsl-latest.tar.gz'
 gsltarpath = os.path.join('deps', 'gsl-latest.tar.gz')
 gslpath = os.path.join('deps', 'gsl')


### PR DESCRIPTION
`setup.py` will create the `deps/` directory if it doesn't exist rather than throwing an error.