### PR TITLE
add 'future' and 'numpy' to setup_requires (for pip)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ setup(
     packages=['pypolyagamma'],
     ext_modules=extensions,
     install_requires=['numpy', 'scipy', 'matplotlib'],
+    setup_requires=['numpy', 'future'],
     classifiers=[
         'Intended Audience :: Science/Research',
         'Programming Language :: Python',


### PR DESCRIPTION
c.f. https://github.com/mattjj/pylds/issues/13
also see https://pip.readthedocs.io/en/1.4.1/cookbook.html#controlling-setup-requires
I think pip/pypi handles `setup_requires` before actually running the setup.py file, via some magic.