### PR TITLE
Fix #15 and Travis CI issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ before_install:
   - conda config --add channels conda-forge
   - echo $TRAVIS_PYTHON_VERSION
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy matplotlib cython nose
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy matplotlib cython nose gxx_linux-64
   - pip install -v -e .
 script: nosetests test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,13 @@ before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.anaconda.com/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda update --yes conda
   - conda config --add channels conda-forge
+  - echo $TRAVIS_PYTHON_VERSION
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy matplotlib cython nose
   - pip install -v -e .

--- a/pypolyagamma/parallel.pyx
+++ b/pypolyagamma/parallel.pyx
@@ -5,7 +5,7 @@
 from cython.parallel import prange, parallel
 from libcpp.vector cimport vector
 
-from openmp cimport omp_get_num_threads, omp_get_thread_num, omp_get_max_threads
+from openmp cimport omp_get_num_threads, omp_get_thread_num, omp_get_max_threads, omp_set_num_threads
 
 cimport pypolyagamma
 import pypolyagamma
@@ -24,6 +24,8 @@ cpdef pgdrawvpar(list ppgs, double[::1] ns, double[::1] zs, double[::1] pgs):
     cdef int S = ns.size
 
     cdef int num_threads, blocklen, sequence_idx_start, sequence_idx_end, thread_num
+
+    omp_set_num_threads(m)
 
     with nogil, parallel():
         # Fix up assignments to avoid cache collisions

--- a/pypolyagamma/parallel.pyx
+++ b/pypolyagamma/parallel.pyx
@@ -5,7 +5,7 @@
 from cython.parallel import prange, parallel
 from libcpp.vector cimport vector
 
-from openmp cimport omp_get_num_threads, omp_get_thread_num, omp_get_max_threads
+from openmp cimport omp_get_num_threads, omp_get_thread_num, omp_get_max_threads, omp_set_num_threads
 
 cimport pypolyagamma
 import pypolyagamma
@@ -24,6 +24,10 @@ cpdef pgdrawvpar(list ppgs, double[::1] ns, double[::1] zs, double[::1] pgs):
     cdef int S = ns.size
 
     cdef int num_threads, blocklen, sequence_idx_start, sequence_idx_end, thread_num
+
+    cdef int max_threads = omp_get_max_threads()
+    if max_threads > m:
+        omp_set_num_threads(m)
 
     with nogil, parallel():
         # Fix up assignments to avoid cache collisions

--- a/pypolyagamma/parallel.pyx
+++ b/pypolyagamma/parallel.pyx
@@ -5,7 +5,7 @@
 from cython.parallel import prange, parallel
 from libcpp.vector cimport vector
 
-from openmp cimport omp_get_num_threads, omp_get_thread_num, omp_get_max_threads, omp_set_num_threads
+from openmp cimport omp_get_num_threads, omp_get_thread_num, omp_get_max_threads
 
 cimport pypolyagamma
 import pypolyagamma
@@ -24,10 +24,6 @@ cpdef pgdrawvpar(list ppgs, double[::1] ns, double[::1] zs, double[::1] pgs):
     cdef int S = ns.size
 
     cdef int num_threads, blocklen, sequence_idx_start, sequence_idx_end, thread_num
-
-    cdef int max_threads = omp_get_max_threads()
-    if max_threads > m:
-        omp_set_num_threads(m)
 
     with nogil, parallel():
         # Fix up assignments to avoid cache collisions

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -110,7 +110,11 @@ def test_density(b=1.0, c=0.0, N_smpls=10000, plot=False):
     return True
 
 def test_parallel2():
+    """Test multiple cases of OMP"""
     num_threads = pypolyagamma.get_omp_num_threads()
+    if num_threads < 2:
+        return
+
     np.random.seed(0)
 
     # Case 1: n < nthreads, nthreads = num_threads

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -109,6 +109,102 @@ def test_density(b=1.0, c=0.0, N_smpls=10000, plot=False):
         plt.show()
     return True
 
+def test_parallel2():
+    num_threads = pypolyagamma.get_omp_num_threads()
+    np.random.seed(0)
+
+    # Case 1: n < nthreads, nthreads = num_threads
+    nthreads = num_threads
+    n = nthreads - 1
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    # Case 2: n < nthreads, nthreads < num_threads
+    nthreads = num_threads - 1
+    n = nthreads - 1
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    # Case 3: n < nthreads, nthreads > num_threads
+    nthreads = num_threads + 1
+    n = nthreads - 1
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    # Case 4: n > nthreads, nthreads = num_threads
+    nthreads = num_threads
+    n = nthreads + 1
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    # Case 5: n > nthreads, nthreads < num_threads
+    nthreads = num_threads - 1
+    n = nthreads + 1
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    # Case 6: n > nthreads, nthreads > num_threads
+    nthreads = num_threads + 1
+    n = nthreads + 1
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    # Case 7: n = nthreads, nthreads = num_threads
+    nthreads = num_threads
+    n = nthreads
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    # Case 8: n = nthreads, nthreads < num_threads
+    nthreads = num_threads - 1
+    n = nthreads
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    # Case 9: n = nthreads, nthreads > num_threads
+    nthreads = num_threads + 1
+    n = nthreads
+    v3 = np.zeros(n)
+    a = 14 * np.ones(n)
+    b = 0 * np.ones(n)
+    seeds = np.random.randint(2**16, size=nthreads)
+    ppgs = [pypolyagamma.PyPolyaGamma(seed) for seed in seeds]
+    pypolyagamma.pgdrawvpar(ppgs, a, b, v3)
+
+    return True
+
 
 if __name__ == "__main__":
     verbose = len(sys.argv) > 1 and (sys.argv[1] == '-v' or sys.argv[1] == "--verbose")
@@ -117,5 +213,6 @@ if __name__ == "__main__":
     assert test_vector_draw(verbose)
     assert test_parallel(verbose)
     assert test_density()
+    assert test_parallel2()
     # ks_test()
     print("Tests passed!")


### PR DESCRIPTION
- `pgs` out-of-bounds caused the segmentation fault caused when the length of `ppgs` is less than `num_threads`. Fix it by setting `num_threads` equal to the length of `ppgs`.

- Apparently miniconda has been changed and fails to downgrade to Python 3.5 from the latest version (3.7 at this PR). Fix it by using an older version.

- The latest conda uses a prefixed gcc compiler that is somehow missing at the installation stage. Fix it by installing `gxx_linux-64` explicitly.