### PR TITLE
scipy compatibility fix

### DIFF
--- a/pypolyagamma/distributions.py
+++ b/pypolyagamma/distributions.py
@@ -3,7 +3,10 @@ import numpy as np
 import numpy.random as npr
 from scipy.special import gammaln
 from scipy.sparse import csr_matrix
-from scipy.misc import logsumexp
+try:
+    from scipy.misc import logsumexp
+except(ImportError):
+    from scipy.special import logsumexp # scipy>=1.3.0
 
 # Name collision in pypolyagamma.pypolyagamma
 # Use relative paths instead (ugh).


### PR DESCRIPTION
Compatibility fix: latest version of scipy (1.3.0) moved `logsumexp`

https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.logsumexp.html